### PR TITLE
Fix phone input regex

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -392,7 +392,7 @@ function App() {
           </div>
           <div className="card-input">
               <FloatLabel>
-                  <InputText id="usernameNumber" keyfilter={/^[+]?(d{1,12})?$/} validateOnly value={valuePhone} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setValuePhone(e.target.value)} />
+                  <InputText id="usernameNumber" keyfilter={/^[+]?(\d{1,12})?$/} validateOnly value={valuePhone} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setValuePhone(e.target.value)} />
                   <label htmlFor="usernameNumber">Phone number</label>
               </FloatLabel>
           </div>


### PR DESCRIPTION
## Summary
- fix the regex in the phone number input field so that digits are validated correctly

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_683f69496210832f9954d21b8b0b6ecc