### PR TITLE
Refine phone validation regex

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -167,9 +167,11 @@ function App() {
     }
     // service_id, templte_id and public key will get from Emailjs website when you create account and add template service and email service
 
-    const checkFields = form.current?.querySelector<UsernameFormElement>('#usernameInput')?.value && 
-        form.current?.querySelector<HTMLInputElement>('#usernameEmail')?.value && 
-        form.current?.querySelector<HTMLInputElement>('#usernameNumber')?.value;
+    const phoneValue = form.current?.querySelector<HTMLInputElement>('#usernameNumber')?.value;
+    const phoneRegex = /^[+]?(\d{1,12})?$/;
+    const checkFields = form.current?.querySelector<UsernameFormElement>('#usernameInput')?.value &&
+        form.current?.querySelector<HTMLInputElement>('#usernameEmail')?.value &&
+        phoneValue && phoneRegex.test(phoneValue);
     if (checkFields) {
         console.log('everything filled')
         console.log(form.current?.querySelector<HTMLInputElement>('#usernameEmail')?.value)


### PR DESCRIPTION
## Summary
- verify user phone numbers using `/^[+]?(\d{1,12})?$/`
- ensure form submission only proceeds when phone digits match the regex

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683f6ef60ecc832faa16684c3e7def80