### PR TITLE
Add floating theme toggle

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -331,3 +331,25 @@ body.dark-mode form button {
   background-color: #90caf9;
   color: #000;
 }
+
+.theme-toggle-floating {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  border: none;
+  background-color: #6193d5;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 1000;
+}
+
+body.dark-mode .theme-toggle-floating {
+  background-color: #90caf9;
+  color: #000;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -223,6 +223,9 @@ function App() {
 
   return (
     <div className="App">
+      <button className='theme-toggle-floating' onClick={toggleDarkMode}>
+        {darkMode ? 'Light' : 'Dark'}
+      </button>
       
       <section className="main-section" id='home'>
         <MenuBar darkMode={darkMode} toggleDarkMode={toggleDarkMode} />

--- a/src/components/MenuBar/MenuBar.css
+++ b/src/components/MenuBar/MenuBar.css
@@ -44,12 +44,6 @@
     align-items: center;
 }
 
-.theme-toggle {
-    background: none;
-    border: none;
-    margin-left: 1rem;
-    cursor: pointer;
-}
 
 .social-media-icon {
     width: 1.5rem;

--- a/src/components/MenuBar/MenuBar.tsx
+++ b/src/components/MenuBar/MenuBar.tsx
@@ -56,7 +56,6 @@ export default function MenuBar({ darkMode, toggleDarkMode }: MenuBarProps) {
                     </a>
                 </li>
             </ul>
-            <button className='theme-toggle' onClick={toggleDarkMode}>{darkMode ? 'Light' : 'Dark'}</button>
         </div>
     );
 


### PR DESCRIPTION
## Summary
- move dark/light toggle from menu bar to floating button
- style new floating button at bottom right

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f849fa408832fb9427a09ec318073