### PR TITLE
Replace text theme toggle with icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest",
+    "test:ci": "vitest run"
   },
   "dependencies": {
     "@emailjs/browser": "^4.4.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -224,7 +224,7 @@ function App() {
   return (
     <div className="App">
       <button className='theme-toggle-floating' onClick={toggleDarkMode}>
-        {darkMode ? 'Light' : 'Dark'}
+        {darkMode ? <i className="pi pi-sun" /> : <i className="pi pi-moon" />}
       </button>
       
       <section className="main-section" id='home'>


### PR DESCRIPTION
## Summary
- show sun/moon icons instead of "Light"/"Dark" text
- add `test:ci` script to run vitest in non-watch mode

## Testing
- `npm run test:ci --silent`

------
https://chatgpt.com/codex/tasks/task_e_683fa2a623b0832f9b18503715472f98