### PR TITLE
Adjust dark mode menu hover

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -321,6 +321,18 @@ body.dark-mode .p-menuitem-content a span {
   color: #e0e0e0;
 }
 
+body.dark-mode .p-menubar .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover .p-menuitem-link {
+  text-decoration: none;
+}
+
+body.dark-mode .p-menubar .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover .p-menuitem-link .p-menuitem-text {
+  color: #4b5563;
+}
+
+body.dark-mode .p-menubar .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover .p-menuitem-link .p-menuitem-icon {
+  color: #4b5563;
+}
+
 body.dark-mode .social-media-icon {
   filter: invert(0.8);
 }


### PR DESCRIPTION
## Summary
- improve dark mode menu styling by setting dark hover colors

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_683fba271798832fb528260e133d8592