### PR TITLE
Refactor to use shared image dataset

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import './App.css';
 import MenuBar from './components/MenuBar/MenuBar';
 
 import React from 'react';
-// import photos from '../data/images.json';
+import photoGallery from '../data/images.json';
 import Lightbox from "yet-another-react-lightbox";
 import "yet-another-react-lightbox/styles.css";
 import Fullscreen from "yet-another-react-lightbox/plugins/fullscreen";
@@ -24,117 +24,6 @@ import { FloatLabel } from "primereact/floatlabel";
 import Carousel from './components/Carousel/Carousel';
 import { InputTextarea } from 'primereact/inputtextarea';
 import { GalleriaDemo } from './components/Galleria/Galleria';
-
-const photoGallery = [
-  {
-    key: "photo-1",
-    src: "/9.jpg",
-    width: 4672,
-    height: 7008,
-    alt: "Nature Scene",
-    title: "Sunset over the mountains",
-    srcSet: []
-  },
-  {
-    key: "photo-2",
-    src: "/2.jpg",
-    width: 4672,
-    height: 7008,
-    alt: "City Skyline",
-    title: "Cityscape at night",
-    srcSet: []
-  },
-  {
-    key: "photo-3",
-    src: "/3.jpg",
-    width: 4184,
-    height: 6276,
-    alt: "Beach Sunset",
-    title: "Relaxing sunset on the beach",
-    srcSet: []
-  },
-  {
-    key: "photo-4",
-    src: "/4.jpg",
-    width: 4672,
-    height: 7008,
-    alt: "Mountain View",
-    title: "Scenic mountain landscape",
-    srcSet: []
-  },
-  {
-    key: "photo-5",
-    src: "/5.jpg",
-    width: 4672,
-    height: 7008,
-    alt: "Forest Pathway",
-    title: "Trail through the forest",
-    srcSet: []
-  },
-  {
-    key: "photo-6",
-    src: "/6.jpg",
-    width: 4379,
-    height: 6568,
-    alt: "Urban Park",
-    title: "Park in the heart of the city",
-    srcSet: []
-  },
-  {
-    key: "photo-7",
-    src: "/7.jpg",
-    width: 3678,
-    height: 5517,
-    alt: "River Reflection",
-    title: "Reflections on the river",
-    srcSet: []
-  },
-  {
-    key: "photo-8",
-    src: "/8.jpg",
-    width: 2967,
-    height: 4450,
-    alt: "New Photo Description",
-    title: "New Photo Title",
-    srcSet: []
-  },
-  {
-    key: "photo-9",
-    src: "/9.jpg",
-    width: 3843,
-    height: 5765,
-    alt: "Another Photo Description",
-    title: "Another Photo Title",
-    srcSet: []
-  },
-  {
-    key: "photo-10",
-    src: "/10.jpg",
-    width: 3972,
-    height: 2648,
-    alt: "Fresh Photo Description",
-    title: "Fresh Photo Title",
-    srcSet: []
-  },
-  {
-    key: "photo-11",
-    src: "/11.jpg",
-    width: 4359,
-    height: 2906,
-    alt: "Latest Photo Description",
-    title: "Latest Photo Title",
-    srcSet: []
-  },
-  {
-    key: "photo-12",
-    src: "/12.jpg",
-    width: 4672,
-    height: 7008,
-    alt: "Newest Photo Description",
-    title: "Newest Photo Title",
-    srcSet: []
-  }
-];
 
 import emailjs from '@emailjs/browser';
 

--- a/src/components/Carousel/Carousel.tsx
+++ b/src/components/Carousel/Carousel.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { Carousel, CarouselResponsiveOption } from 'primereact/carousel';
 import { Image } from 'primereact/image';
 import './Carousel.css';
+import photoGallery from '../../../data/images.json';
 
 type Photo = {
     original: string;
@@ -10,63 +11,11 @@ type Photo = {
     originalClass: string;
 };
 
-const images = [
-    {
-        original: "https://lh3.googleusercontent.com/pw/AP1GczOld6PSubj59q9QjcN2hEuPig-6P2SfBsPvIZ6K2V5HcpkqIas8nt1hbB1nFdhSjZnm_pB4JqNO0Usly5WwaeujkZrYmfdWsFCbfa4P-vuyYAuu00lldPcNpFlLYgIv0KsN1b85SWFaOk-fTwb67q2t=w687-h1031-s-no-gm?authuser=0",
-        thumbnail: "",
-        originalClass: "gallery-image",
-    },
-    {
-        original: "https://lh3.googleusercontent.com/pw/AP1GczM6XgTxBQ4i551o8FvmSll-d96sVtWZT_blQ14arM1gHzK7Yf4BuVNqGChXeYKW5G892P81hxABiFQcLEK7V79dRPFS518b5J-0OiDvFn8CD33_BzTByks4G4Wia2rS4AzXKNhpeqhzoDk-szJTNLki=w687-h1031-s-no-gm?authuser=0",
-        thumbnail: "",
-        originalClass: "gallery-image",
-    },
-    {
-        original: "https://lh3.googleusercontent.com/pw/AP1GczNa6ZIUeJ5dKSxFY4G1qD4GmJ3IEd5P7rrVMt3OWSfsZduXuLlXZAGa8lh49dDqexXcOOuFiy7OAbwfJpjuaHXy7jqOYXyAJFyOPr5C6l0uyCj4AJ4fyj0qqoO4-5OSti4JIg7MOsCmgppAsu2isCZK=w687-h1031-s-no-gm?authuser=0",
-        thumbnail: "",
-        originalClass: "gallery-image",
-    },
-    {
-        original: "https://lh3.googleusercontent.com/pw/AP1GczOdr4dkqh4icZL7BmjHis-PMcsHc6Jmob0MMXYLYRdApDcSl8JmAx0PcH5Sdy95m-w8xWibet-x7ddr_lKz1oByIN0RgTG736iX8TOZf5KHYJqS_fxMyCYdE6QqXZKmQr-wn_hkDKmjOW5hWxKycRKZ=w687-h1031-s-no-gm?authuser=0",
-        thumbnail: "",
-        originalClass: "gallery-image",
-    },
-    {
-        original: "https://lh3.googleusercontent.com/pw/AP1GczOVv4Jok36xcSNDvETYjKpaggUtqJ7wjcF-OJZSTl5bIrq9Bg0t-gOPl2eRREjQl916ScWQFLIDWAWpzQRn8XasG7myQv03s9-g-XQit7aZxriDuSbi-SgZ0YwdBHG4lvNRC2EhUPmSjPmgn1TG3Fi3=w687-h1031-s-no-gm?authuser=0",
-        thumbnail: "",
-        originalClass: "gallery-image",
-    },
-    {
-        original: "https://lh3.googleusercontent.com/pw/AP1GczOk_Ek3dPyaEcHXABxzUzgdhYo7dX6D3ORrpJiTt-EkdFSBHVTXdL4RxvNdWjAw8Y2pqUDXlK_nuN3zipBcO8tHNWatgx04rwpvwBwL56Ry9wdZ4ekZYhDb0l6x8kea1ALF5SI68RUNdmAwfB826l57=w687-h1031-s-no-gm?authuser=0",
-        thumbnail: "",
-        originalClass: "gallery-image",
-    },
-    {
-        original: "https://lh3.googleusercontent.com/pw/AP1GczOxZWAnIH9xCXNZZU4X3UygCjypaEQN37CP9IGjIiBSOLL1Ddix94zp7RDB3ibDjKoYtxZOdAIJLMTOGg3xs1wC6PZYT6onh73JDa6awAXyLGavcO2ErtrGIGaDvrTpUk-Ee_gRawJkKCBkeiBc9N2K=w687-h1031-s-no-gm?authuser=0",
-        thumbnail: "",
-        originalClass: "gallery-image",
-    },
-    {
-        original: "https://lh3.googleusercontent.com/pw/AP1GczMUFKYGT01gydJFZ1ZgejSUTiVVFLCKJ4ko48eNo3-C2i9eF8LdN5G6XaWl7VRZWnidyrE-8NtbRsiXUzXQvXLMzOUK6DPNsJDDF9Y6d1CYzkRFEHG3z6pAy5zN5y5EuYxLUPZq4fFkWanZT0kpLxXO=w687-h1031-s-no-gm?authuser=0",
-        thumbnail: "",
-        originalClass: "gallery-image",
-    },
-    {
-        original: "https://lh3.googleusercontent.com/pw/AP1GczPRDuLukVNN_1-2wrvzf4d9urAYP877PGchnEDxiNNsx-8ntV-CSiQablsdCRFY2QJC5E5dCqMEPgcG-YO7wBm5pos4Iyq8uvfi6kuj4mY9m2aEtj7RMlcaQ9ss2L5dtYqCpZVNlHasZrsQjv_ofu05=w687-h1031-s-no-gm?authuser=0",
-        thumbnail: "",
-        originalClass: "gallery-image",
-    },
-    {
-        original: "https://lh3.googleusercontent.com/pw/AP1GczNnJycaEbSrdny2QWD4-LmRJc17Eh81UP2C_M3_q04I869GTHWiSJkgOG1DLdkRIQvBGhFiztAvRWAPe5siZJG-5SCT_YgfaIFCAJEF206i5aqWQ1xIyZSWAGCUbSE_TfIqOpCRi5swTC74FtR2gzph=w687-h1031-s-no-gm?authuser=0",
-        thumbnail: "",
-        originalClass: "gallery-image",
-    },
-    {
-        original: "https://lh3.googleusercontent.com/pw/AP1GczNAYUTS09FCBQqtuaZF_R4MdqOeVmtK3lpn-2_O__Gc6C1N0TAYGlckTn0kntA-1SvgS5Cv2mQmooQnCgJ59Kz8qoZvLRgWZsIA1GxvaBRO31yZegtPYo-JvqVoXb01MLnj5LF7AqIRAeQqKfQYiPtp=w687-h1031-s-no-gm?authuser=0",
-        thumbnail: "",
-        originalClass: "gallery-image",
-    },
-];
+const images: Photo[] = photoGallery.map((img) => ({
+    original: img.src,
+    thumbnail: '',
+    originalClass: 'gallery-image',
+}));
 
 export default function ResponsiveDemo() {
     const [products] = useState<Photo[]>(images);

--- a/src/components/Galleria/Galleria.tsx
+++ b/src/components/Galleria/Galleria.tsx
@@ -2,6 +2,7 @@
 import { useState, FC } from 'react';
 import { Galleria } from 'primereact/galleria';
 import './Galleria.css'
+import photoGallery from '../../../data/images.json';
 
 type Photo = {
     original: string;
@@ -9,29 +10,11 @@ type Photo = {
     originalClass: string;
 };
 
-const photos = [
-    {
-      original: "https://lh3.googleusercontent.com/pw/AP1GczMJhYrowIh_Ljd_48bNaLNAva-L6helEH-k60E7cFHlxxQdrLEXyYNgC45o_pxmSf0JrWBMNsJTQgHyFoz-SdKfUGkfkglBG47tFXJNyIIpck0TTuQ1YP1vOHYMkUHZOG_lh7hsSuUkGzG8qrar05Fe=w1546-h1031-s-no-gm?authuser=0",
-      thumbnail: "",
-      originalClass: "gallery-image",
-      
-    },
-    {
-      original: "https://lh3.googleusercontent.com/pw/AP1GczND_WK21qs2orG3n-VtAzZMQRViBtlHILgqwM7wh9Dv5GHI02a67JkZCsgGMuzQ6uj6gemP_nVtix2DpoGM1YRaVi0PjX9lrLRyV3nY17jnWmfh_O3xr_NrwVLU9TVZZnXu_HJmx-oAvOpkwGllskJo=w1546-h1031-s-no-gm?authuser=0",
-      thumbnail: "",
-      originalClass: "gallery-image",
-    },
-    {
-      original: "https://lh3.googleusercontent.com/pw/AP1GczPf4QeGHU7yROecUM79wNVvC0FUEHlruPBRu5aUcHsrJDQhpZcmz-ZtEkCNHST1_pqy5SRAKDqzA9l3-Ab-CjTMdxBb3yepRfI8edcmbFSupaBX4p8jcoGGT-ZKT-L90wyz5_yKUCVGB9oQtohSFQf9=w1547-h1031-s-no-gm?authuser=0",
-      thumbnail: "",
-      originalClass: "gallery-image",
-    },
-    {
-      original: "https://lh3.googleusercontent.com/pw/AP1GczOFjGC8by1IIO7e7BhgVuS6Rf3-SLp-SJdNSwrRB3tStyvX_m3vL472CNEEsKqSMfA04LWiyRf2HY1DH6Gw1qQwFWpRnnOEsri2Cd5_gSYOhUQNMCYI7nBbaMqkOdrkMrPEXV4BjMPhgzX7o7G_6ASS=w1546-h1031-s-no-gm?authuser=0",
-      thumbnail: "",
-      originalClass: "gallery-image",
-    },
-  ];
+const photos: Photo[] = photoGallery.map((img) => ({
+    original: img.src,
+    thumbnail: '',
+    originalClass: 'gallery-image',
+}));
 
 export const GalleriaDemo: FC = () => {
     const [images] = useState(photos)


### PR DESCRIPTION
## Summary
- remove hardcoded image arrays from components
- load images from `data/images.json` instead
- map dataset for Carousel and Galleria views

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_683fddb830a0832fb5885ec84997ba05