### PR TITLE
Add unit tests for new components

### DIFF
--- a/src/__tests__/carousel.test.tsx
+++ b/src/__tests__/carousel.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react'
+import ResponsiveDemo from '../components/Carousel/Carousel'
+import { vi } from 'vitest'
+
+vi.mock('primereact/carousel', () => ({
+  Carousel: ({ value, itemTemplate }: any) => (
+    <div data-testid="carousel">{value.map(itemTemplate)}</div>
+  )
+}))
+
+vi.mock('primereact/image', () => ({
+  Image: (props: any) => <img {...props} />
+}))
+
+describe('Carousel component', () => {
+  it('renders all carousel images', () => {
+    render(<ResponsiveDemo />)
+    const images = screen.getAllByRole('img')
+    expect(images.length).toBe(11)
+  })
+})

--- a/src/__tests__/galleria.test.tsx
+++ b/src/__tests__/galleria.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react'
+import { GalleriaDemo } from '../components/Galleria/Galleria'
+import { vi } from 'vitest'
+
+vi.mock('primereact/galleria', () => ({
+  Galleria: ({ value, item }: any) => (
+    <div data-testid="galleria">{value.map(item)}</div>
+  )
+}))
+
+vi.mock('primereact/image', () => ({
+  Image: (props: any) => <img {...props} />
+}))
+
+describe('GalleriaDemo component', () => {
+  it('renders images inside galleria', () => {
+    render(<GalleriaDemo />)
+    const images = screen.getAllByRole('img')
+    expect(images.length).toBe(4)
+  })
+})

--- a/src/__tests__/gallerySection.test.tsx
+++ b/src/__tests__/gallerySection.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react'
+import GallerySection from '../components/GallerySection/GallerySection'
+import { vi } from 'vitest'
+
+vi.mock('../components/Carousel/Carousel', () => ({
+  default: () => <div data-testid='carousel-mock' />
+}))
+
+vi.mock('yet-another-react-lightbox', () => ({
+  __esModule: true,
+  default: () => <div data-testid='lightbox-mock' />
+}))
+
+describe('GallerySection component', () => {
+  it('renders headings and subcomponents', () => {
+    render(<GallerySection />)
+    expect(screen.getByText(/Shoot portraits/i)).toBeInTheDocument()
+    expect(screen.getByTestId('carousel-mock')).toBeInTheDocument()
+    expect(screen.getByTestId('lightbox-mock')).toBeInTheDocument()
+  })
+})

--- a/src/__tests__/packagesSection.test.tsx
+++ b/src/__tests__/packagesSection.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react'
+import PackagesSection from '../components/PackagesSection/PackagesSection'
+import { vi } from 'vitest'
+
+vi.mock('primereact/image', () => ({
+  Image: (props: any) => <img {...props} />
+}))
+
+describe('PackagesSection component', () => {
+  it('renders package pricing tables', () => {
+    render(<PackagesSection />)
+    expect(screen.getByText(/Package Pricing/i)).toBeInTheDocument()
+    expect(screen.getAllByRole('table').length).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## Summary
- test Carousel image rendering
- test GalleriaDemo image rendering
- test GallerySection subcomponents
- test PackagesSection tables

## Testing
- `npm run test:ci --silent`

------
https://chatgpt.com/codex/tasks/task_e_683fe3026b38832f92763e9adfd1699d