### PR TITLE
Refactor components

### DIFF
--- a/src/components/Carousel/Carousel.tsx
+++ b/src/components/Carousel/Carousel.tsx
@@ -1,5 +1,5 @@
 
-import { useState } from 'react';
+import { memo } from 'react';
 import { Carousel, CarouselResponsiveOption } from 'primereact/carousel';
 import { Image } from 'primereact/image';
 import './Carousel.css';
@@ -68,9 +68,7 @@ const images = [
     },
 ];
 
-export default function ResponsiveDemo() {
-    const [products] = useState<Photo[]>(images);
-    const responsiveOptions: CarouselResponsiveOption[] = [
+const responsiveOptions: CarouselResponsiveOption[] = [
         {
             breakpoint: '1590px',
             numVisible: 4,
@@ -98,30 +96,36 @@ export default function ResponsiveDemo() {
         }
     ];
 
+const productTemplate = (product: Photo) => (
+    <div className="border-1 surface-border border-round m-2 text-center py-5 px-3">
+        <Image src={product.original} width='340px' />
+    </div>
+);
 
-    const productTemplate = (product: Photo) => {
-        return (
-            <div className="border-1 surface-border border-round m-2 text-center py-5 px-3">
-                <Image src={product.original} width='340px' />
-            </div>
-        );
-    };
+const NextIcon = () => (
+    <svg className="image-gallery-svg" xmlns="http://www.w3.org/2000/svg" viewBox="6 0 12 24" fill="none" stroke="currentColor" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
+);
 
-    const nextIcon = () => {
-        return (
-            <svg className="image-gallery-svg" xmlns="http://www.w3.org/2000/svg" viewBox="6 0 12 24" fill="none" stroke="currentColor" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
-        )
-    }
+const PrevIcon = () => (
+    <svg className="image-gallery-svg" xmlns="http://www.w3.org/2000/svg" viewBox="6 0 12 24" fill="none" stroke="currentColor" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
+);
 
-    const PrevIcon = () => {
-        return (
-            <svg className="image-gallery-svg" xmlns="http://www.w3.org/2000/svg" viewBox="6 0 12 24" fill="none" stroke="currentColor" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
-        )
-    }
-
+function ResponsiveDemo() {
     return (
         <div className="card-carousel">
-            <Carousel autoplayInterval={2000} circular={true} value={products} numScroll={1} numVisible={4} responsiveOptions={responsiveOptions} itemTemplate={productTemplate} prevIcon={PrevIcon} nextIcon={nextIcon} />
+            <Carousel
+                autoplayInterval={2000}
+                circular
+                value={images}
+                numScroll={1}
+                numVisible={4}
+                responsiveOptions={responsiveOptions}
+                itemTemplate={productTemplate}
+                prevIcon={PrevIcon}
+                nextIcon={NextIcon}
+            />
         </div>
-    )
+    );
 }
+
+export default memo(ResponsiveDemo);

--- a/src/components/ContactForm/ContactForm.tsx
+++ b/src/components/ContactForm/ContactForm.tsx
@@ -1,19 +1,8 @@
-import { useRef, useState } from 'react';
+import { useRef, useState, useCallback } from 'react';
 import { InputText } from 'primereact/inputtext';
 import { InputTextarea } from 'primereact/inputtextarea';
 import { FloatLabel } from 'primereact/floatlabel';
 import emailjs from '@emailjs/browser';
-
-interface FormElements extends HTMLFormControlsCollection {
-  usernameInput: HTMLInputElement;
-  usernameEmail: HTMLInputElement;
-  usernameNumber: HTMLInputElement;
-  usernameMessage: HTMLInputElement;
-}
-
-interface UsernameFormElement extends HTMLFormElement {
-  readonly elements: FormElements;
-}
 
 export default function ContactForm() {
   const [sendButtonText, setSendButtonText] = useState('Send');
@@ -23,18 +12,17 @@ export default function ContactForm() {
   const [valueDescription, setValueDescription] = useState('');
   const form = useRef<HTMLFormElement>(null);
 
-  const sendEmail = async (event: React.FormEvent) => {
+  const sendEmail = useCallback(async (event: React.FormEvent) => {
     event.preventDefault();
     if (sendButtonText === 'Message sent!') {
       return;
     }
-    const phoneValue = form.current?.querySelector<HTMLInputElement>('#usernameNumber')?.value;
     const phoneRegex = /^[+]?(\d{1,12})?$/;
     const checkFields =
-      form.current?.querySelector<UsernameFormElement>('#usernameInput')?.value &&
-      form.current?.querySelector<HTMLInputElement>('#usernameEmail')?.value &&
-      phoneValue &&
-      phoneRegex.test(phoneValue);
+      valueName &&
+      valueEmail &&
+      valuePhone &&
+      phoneRegex.test(valuePhone);
     if (checkFields) {
       await emailjs
         .send(
@@ -52,13 +40,13 @@ export default function ContactForm() {
           }
         );
     }
-  };
+  }, [sendButtonText, valueName, valueEmail, valuePhone, valueDescription]);
 
-  const refreshSendButton = () => {
+  const refreshSendButton = useCallback(() => {
     if (sendButtonText === 'Message sent!') {
       setSendButtonText('Send');
     }
-  };
+  }, [sendButtonText]);
 
   return (
     <section className="contact-section" id="contact">

--- a/src/components/Galleria/Galleria.tsx
+++ b/src/components/Galleria/Galleria.tsx
@@ -1,5 +1,5 @@
 
-import { useState, FC } from 'react';
+import { memo, FC } from 'react';
 import { Galleria } from 'primereact/galleria';
 import './Galleria.css'
 
@@ -33,34 +33,40 @@ const photos = [
     },
   ];
 
-export const GalleriaDemo: FC = () => {
-    const [images] = useState(photos)
+const itemTemplate = (item: Photo) => (
+    <img
+        src={item.original}
+        style={{ width: '100%', display: 'block', height: 'calc(100vh - 10rem)', objectFit: 'cover' }}
+    />
+);
 
+const NextIcon = () => (
+    <svg className="image-gallery-svg" xmlns="http://www.w3.org/2000/svg" viewBox="6 0 12 24" fill="none" stroke="currentColor" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
+);
 
-    const itemTemplate = (item: Photo) => {
-        return <img src={item.original} style={{ width: '100%', display: 'block', height: 'calc(100vh - 10rem)', objectFit: 'cover',  }} />;
-    }
+const PrevIcon = () => (
+    <svg className="image-gallery-svg" xmlns="http://www.w3.org/2000/svg" viewBox="6 0 12 24" fill="none" stroke="currentColor" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
+);
 
-    const nextIcon = () => {
-      return (
-          <svg className="image-gallery-svg" xmlns="http://www.w3.org/2000/svg" viewBox="6 0 12 24" fill="none" stroke="currentColor" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
-      )
-    }
-
-    const PrevIcon = () => {
-        return (
-            <svg className="image-gallery-svg" xmlns="http://www.w3.org/2000/svg" viewBox="6 0 12 24" fill="none" stroke="currentColor" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
-        )
-    }
-
-
+export const GalleriaDemo: FC = memo(() => {
     return (
-        <div className="card-carousel"> 
-            <Galleria value={images} numVisible={5} circular style={{ maxWidth: '100vw' }} 
-                showItemNavigators showItemNavigatorsOnHover showIndicators
-                showThumbnails={false} item={itemTemplate} itemNextIcon={nextIcon} itemPrevIcon={PrevIcon}
-                autoPlay transitionInterval={2500}/>
+        <div className="card-carousel">
+            <Galleria
+                value={photos}
+                numVisible={5}
+                circular
+                style={{ maxWidth: '100vw' }}
+                showItemNavigators
+                showItemNavigatorsOnHover
+                showIndicators
+                showThumbnails={false}
+                item={itemTemplate}
+                itemNextIcon={NextIcon}
+                itemPrevIcon={PrevIcon}
+                autoPlay
+                transitionInterval={2500}
+            />
         </div>
-    )
-}
+    );
+});
         

--- a/src/components/GallerySection/GallerySection.tsx
+++ b/src/components/GallerySection/GallerySection.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, memo } from 'react';
 import Lightbox from "yet-another-react-lightbox";
 import "yet-another-react-lightbox/styles.css";
 import Fullscreen from "yet-another-react-lightbox/plugins/fullscreen";
@@ -119,7 +119,7 @@ const photoGallery = [
   }
 ];
 
-export default function GallerySection() {
+function GallerySection() {
   const [index, setIndex] = useState(-1);
 
   return (
@@ -139,3 +139,5 @@ export default function GallerySection() {
     </section>
   );
 }
+
+export default memo(GallerySection);

--- a/src/components/MenuBar/MenuBar.tsx
+++ b/src/components/MenuBar/MenuBar.tsx
@@ -1,10 +1,11 @@
 import { Menubar } from 'primereact/menubar';
 import { MenuItem } from 'primereact/menuitem';
 import { Image } from 'primereact/image';
+import { memo, useMemo } from 'react';
 import '../MenuBar/MenuBar.css';
 
-export default function MenuBar() {
-    const items: MenuItem[] = [
+function MenuBar() {
+    const items: MenuItem[] = useMemo(() => [
         {
             label: 'Home',
             icon: 'pi pi-home',
@@ -25,7 +26,7 @@ export default function MenuBar() {
             icon: 'pi pi-envelope',
             url: '#contact'
         }
-    ];
+    ], []);
 
     const end = (
         <div className='end-wrapper'>
@@ -73,4 +74,6 @@ export default function MenuBar() {
         </div>
     )
 }
+
+export default memo(MenuBar);
         

--- a/src/components/PackagesSection/PackagesSection.tsx
+++ b/src/components/PackagesSection/PackagesSection.tsx
@@ -1,6 +1,7 @@
 import { Image } from 'primereact/image';
+import { memo } from 'react';
 
-export default function PackagesSection() {
+function PackagesSection() {
   return (
     <section className="package-section" id="pricing">
       <h1>Package Pricing</h1>
@@ -133,3 +134,5 @@ export default function PackagesSection() {
     </section>
   );
 }
+
+export default memo(PackagesSection);


### PR DESCRIPTION
## Summary
- use `memo` and `useMemo` to optimize MenuBar
- memoize images for galleria and carousel
- use callbacks for contact form actions
- wrap gallery, packages and menu components with `memo`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68405d7c7144832f9c4e23aa4de8e713